### PR TITLE
gts4lv-common: Remove timeservice_app_cert certificate

### DIFF
--- a/gts4lv-common/Android.bp
+++ b/gts4lv-common/Android.bp
@@ -109,7 +109,7 @@ android_app_import {
 	name: "TimeService",
 	owner: "samsung",
 	apk: "proprietary/vendor/app/TimeService/TimeService.apk",
-	certificate: ":timeservice_app_cert",
+	certificate: "platform",
 	dex_preopt: {
 		enabled: false,
 	},


### PR DESCRIPTION
* This cert was removed in R qcom sepolicy...

Originally taken from and had no change ID:
https://github.com/Evolution-X-Devices/vendor_xiaomi/commit/99709caa7009e3b2b645fbae4b58c8fa14d1715c